### PR TITLE
fix: redirect on missing provider details being very laggy

### DIFF
--- a/apps/frontend/src/lib/provider/use-active-email-address.ts
+++ b/apps/frontend/src/lib/provider/use-active-email-address.ts
@@ -8,6 +8,7 @@ import { useLogger } from "../logger";
 import {
   ROUTE_EMAIL_PROVIDER_DEFAULT_INBOX,
   ROUTE_EMAIL_PROVIDER_INBOX,
+  ROUTE_ONBOARDING_CONNECT,
 } from "../routes";
 
 export const useActiveEmailAddress = () => {
@@ -23,9 +24,19 @@ export const useActiveEmailAddress = () => {
   useEffect(() => {
     const checkValidProviderId = async () => {
       const provider = await getProviderById({ id: providerId });
-      if (!provider && providerId !== ROUTE_EMAIL_PROVIDER_DEFAULT_INBOX) {
+      if (provider) {
+        return;
+      }
+
+      if (providerId !== ROUTE_EMAIL_PROVIDER_DEFAULT_INBOX) {
         router.push(
           ROUTE_EMAIL_PROVIDER_INBOX(ROUTE_EMAIL_PROVIDER_DEFAULT_INBOX),
+        );
+      } else if (providerId === ROUTE_EMAIL_PROVIDER_DEFAULT_INBOX) {
+        router.push(
+          ROUTE_ONBOARDING_CONNECT({
+            type: "initialConnection",
+          }),
         );
       }
     };


### PR DESCRIPTION
# Pull Request

## Stories

- (frontend): As a user, I am now redirected to the right place, so that I am not confused as to what to do

## Screenshots

None

## How PR was tested

- checkout PR
- `ni` at the top level directory
- visit `http://localhost:3000/5` redirect properly
